### PR TITLE
Add local test script to test reporter

### DIFF
--- a/reporter/local-test.sh
+++ b/reporter/local-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if ! oc get svc mongodb > /dev/null 2>&1; then
+    echo "MongoDB service not found"
+    echo "Make sure you are using a kubeconfig that has access to the running cluster and has the ci-testgrid namespace"
+    exit 1
+fi
+
+oc port-forward svc/mongodb 27017:27017 &
+export GITHUB_TOKEN=$(oc get secret github-token -o jsonpath='{.data.token}' | base64 -d)
+
+# Set the MongoDB URI and database name
+export MONGODB_URI="mongodb://localhost:27017"
+export DRY_RUN=true
+
+go run main.go


### PR DESCRIPTION
This commit introduces a local testing utility script for the reporter component, enabling developers to easily test the reporter functionality against a live cluster environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a script to simplify local testing with a MongoDB service running in Kubernetes. The script sets up port forwarding, retrieves necessary credentials, and runs the application in dry-run mode using local environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->