### PR TITLE
Update container images to Red Hat UBI 9

### DIFF
--- a/dbpruner/Dockerfile
+++ b/dbpruner/Dockerfile
@@ -1,13 +1,8 @@
 # Build stage - using public UBI image (no auth required)
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21 AS builder
-
-# Switch to root to install packages and set up build environment
-USER root
-
-# Install git (needed for go modules)
-RUN dnf update -y && dnf install -y git && dnf clean all
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
 # Set working directory
+USER root
 WORKDIR /build
 
 # Copy go mod files
@@ -25,7 +20,7 @@ COPY types/ ./types/
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o dbpruner main.go
 
 # Final stage - minimal runtime image (public access)
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 # Add Red Hat container labels
 LABEL name="ci-testgrid-dbpruner" \

--- a/dbpruner/Makefile
+++ b/dbpruner/Makefile
@@ -3,9 +3,11 @@
 
 # Container engine (podman preferred for Red Hat ecosystem)
 CONTAINER_ENGINE ?= podman
-IMAGE_NAME ?= quay.io/hypershift/ci-testgrid-dbpruner:latest
+IMAGE_TAG ?= $(shell date +%Y-%m-%d)
+IMAGE_NAME ?= quay.io/hypershift/ci-testgrid-dbpruner:$(IMAGE_TAG)
+AUTHFILE ?= $(HOME)/.hypershift-push
 
-.PHONY: build clean run help deps image
+.PHONY: build clean run help deps image push
 
 # Build the dbpruner binary
 build:
@@ -27,6 +29,9 @@ run:
 # Container image targets
 image:
 	$(CONTAINER_ENGINE) build --arch=amd64 --os=linux -t $(IMAGE_NAME) .
+
+push: image
+	$(CONTAINER_ENGINE) push --authfile $(AUTHFILE) $(IMAGE_NAME)
 
 
 

--- a/dbpruner/k8s/cleanup-cronjob.yaml
+++ b/dbpruner/k8s/cleanup-cronjob.yaml
@@ -19,7 +19,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: dbpruner
-            image: quay.io/hypershift/ci-testgrid-dbpruner:latest
+            image: quay.io/hypershift/ci-testgrid-dbpruner:2026-02-23
             imagePullPolicy: Always
             command:
             - /app/dbpruner

--- a/reporter/Dockerfile
+++ b/reporter/Dockerfile
@@ -1,11 +1,8 @@
 # Build stage
-FROM golang:1.24.1-alpine AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
-# Install git and build dependencies
-RUN apk add --no-cache git make
-
-# Set working directory
-WORKDIR /app
+USER root
+WORKDIR /build
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
@@ -20,15 +17,15 @@ COPY . .
 RUN make build
 
 # Final stage
-FROM alpine:3.19
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 # Install ca-certificates for HTTPS requests
-RUN apk add --no-cache ca-certificates
+RUN microdnf install -y ca-certificates && microdnf clean all
 
 WORKDIR /app
 
 # Copy the binary from builder
-COPY --from=builder /app/bin/ci-reporter /app/reporter
+COPY --from=builder /build/bin/ci-reporter /app/reporter
 
 # Set the entrypoint
-ENTRYPOINT ["/app/reporter"] 
+ENTRYPOINT ["/app/reporter"]

--- a/reporter/Makefile
+++ b/reporter/Makefile
@@ -1,6 +1,8 @@
 BINARY_NAME=bin/ci-reporter
 CONTAINER_ENGINE ?= podman
-IMAGE_NAME=quay.io/hypershift/ci-reporter:latest
+IMAGE_TAG ?= $(shell date +%Y-%m-%d)
+IMAGE_NAME=quay.io/hypershift/ci-reporter:$(IMAGE_TAG)
+AUTHFILE ?= $(HOME)/.hypershift-push
 
 build:
 	go build -o ${BINARY_NAME} main.go
@@ -16,4 +18,7 @@ clean:
 	rm -f ${BINARY_NAME}
 
 image:
-	${CONTAINER_ENGINE} build --arch=amd64 --os=linux -t ${IMAGE_NAME} . 
+	${CONTAINER_ENGINE} build --arch=amd64 --os=linux -t ${IMAGE_NAME} .
+
+push: image
+	${CONTAINER_ENGINE} push --authfile ${AUTHFILE} ${IMAGE_NAME}

--- a/reporter/k8s/reporter-cronjob.yaml
+++ b/reporter/k8s/reporter-cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: cijobs-reporter
-            image: quay.io/hypershift/ci-reporter:latest
+            image: quay.io/hypershift/ci-reporter:2026-02-23
             imagePullPolicy: Always
             env:
             - name: MONGO_URI

--- a/scraper/Dockerfile
+++ b/scraper/Dockerfile
@@ -1,11 +1,8 @@
 # Build stage
-FROM golang:1.24.1-alpine AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
-# Install git and build dependencies
-RUN apk add --no-cache git make
-
-# Set working directory
-WORKDIR /app
+USER root
+WORKDIR /build
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
@@ -20,15 +17,15 @@ COPY . .
 RUN make build
 
 # Final stage
-FROM alpine:3.19
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 # Install ca-certificates for HTTPS requests
-RUN apk add --no-cache ca-certificates
+RUN microdnf install -y ca-certificates && microdnf clean all
 
 WORKDIR /app
 
 # Copy the binary from builder
-COPY --from=builder /app/bin/ci-scraper /app/scraper
+COPY --from=builder /build/bin/ci-scraper /app/scraper
 
 # Set the entrypoint
-ENTRYPOINT ["/app/scraper"] 
+ENTRYPOINT ["/app/scraper"]

--- a/scraper/Makefile
+++ b/scraper/Makefile
@@ -1,6 +1,8 @@
 BINARY_NAME=bin/ci-scraper
 CONTAINER_ENGINE ?= podman
-IMAGE_NAME=quay.io/hypershift/ci-scraper:latest
+IMAGE_TAG ?= $(shell date +%Y-%m-%d)
+IMAGE_NAME=quay.io/hypershift/ci-scraper:$(IMAGE_TAG)
+AUTHFILE ?= $(HOME)/.hypershift-push
 
 build:
 	go build -o ${BINARY_NAME} main.go
@@ -17,4 +19,7 @@ clean:
 
 image:
 	${CONTAINER_ENGINE} build --arch=amd64 --os=linux -t ${IMAGE_NAME} .
+
+push: image
+	${CONTAINER_ENGINE} push --authfile ${AUTHFILE} ${IMAGE_NAME}
 

--- a/scraper/k8s/mongodb-deployment.yaml
+++ b/scraper/k8s/mongodb-deployment.yaml
@@ -15,6 +15,8 @@ metadata:
   name: mongodb
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: mongodb
@@ -25,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mongodb
-        image: docker.io/library/mongo:latest
+        image: quay.io/mongodb/mongodb-community-server:8.2.5-ubi9
         ports:
         - containerPort: 27017
         volumeMounts:

--- a/scraper/k8s/scraper-cronjob.yaml
+++ b/scraper/k8s/scraper-cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: cijobs-scraper
-            image: quay.io/hypershift/ci-scraper:latest
+            image: quay.io/hypershift/ci-scraper:2026-02-23
             imagePullPolicy: Always
             env:
             - name: MONGODB_HOST

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,11 +1,8 @@
 # Build stage
-FROM golang:1.24.1-alpine AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
 
-# Install build dependencies
-RUN apk add --no-cache git
-
-# Set working directory
-WORKDIR /app
+USER root
+WORKDIR /build
 
 # Copy go mod and sum files
 COPY go.mod go.sum ./
@@ -20,19 +17,20 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o ci-testgrid-ui main.go
 
 # Final stage
-FROM alpine:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 # Install runtime dependencies
-RUN apk add --no-cache ca-certificates tzdata
+RUN microdnf install -y ca-certificates tzdata shadow-utils && microdnf clean all
 
 # Create non-root user
-RUN adduser -D -g '' appuser
+RUN groupadd -g 1001 appgroup && \
+    useradd -u 1001 -g appgroup -m -s /bin/bash appuser
 
 # Set working directory
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /app/ci-testgrid-ui .
+COPY --from=builder /build/ci-testgrid-ui .
 
 # Use non-root user
 USER appuser
@@ -41,4 +39,4 @@ USER appuser
 EXPOSE 8080
 
 # Run the application
-CMD ["./ci-testgrid-ui"] 
+CMD ["./ci-testgrid-ui"]

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,7 +1,9 @@
 # Binary name
 BINARY_NAME=ci-testgrid-ui
 CONTAINER_ENGINE ?= podman
-IMAGE_NAME=quay.io/hypershift/ci-testgrid-ui:latest
+IMAGE_TAG ?= $(shell date +%Y-%m-%d)
+IMAGE_NAME=quay.io/hypershift/ci-testgrid-ui:$(IMAGE_TAG)
+AUTHFILE ?= $(HOME)/.hypershift-push
 
 # Go commands
 GOCMD=go
@@ -42,4 +44,7 @@ run: build
 image:
 	${CONTAINER_ENGINE} build --arch=amd64 --os=linux -t ${IMAGE_NAME} .
 
-.PHONY: all build test clean deps run image
+push: image
+	${CONTAINER_ENGINE} push --authfile ${AUTHFILE} ${IMAGE_NAME}
+
+.PHONY: all build test clean deps run image push

--- a/ui/k8s/deployment.yaml
+++ b/ui/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: ci-testgrid-ui
-        image: quay.io/hypershift/ci-testgrid-ui:latest
+        image: quay.io/hypershift/ci-testgrid-ui:2026-02-23
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Summary
- Replace `docker.io/library/mongo:latest` with `quay.io/mongodb/mongodb-community-server:8.2.5-ubi9`
- Switch all Dockerfiles from Alpine / UBI 8 base images to UBI 9 (`ubi9/go-toolset` for build, `ubi9/ubi-minimal:9.7` for runtime)
- Remove unnecessary `dnf install` steps (git and make are already included in `ubi9/go-toolset`)
- Add `Recreate` strategy to MongoDB deployment for RWO PVC compatibility
- Add `push` target and `IMAGE_TAG` / `AUTHFILE` variables to all Makefiles
- Pin k8s manifests to `2026-02-23` image tag instead of `latest`

## Test plan
- [x] All four container images build successfully with `make image`
- [x] All four images pushed to quay.io with `make push`
- [x] MongoDB deployment updated in cluster — verified same version (8.2.5), data intact (857 documents)
- [x] UI deployment rolled out successfully
- [x] CronJobs (reporter, scraper, dbpruner) updated with new image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container images to UBI9 for enhanced security and stability
  * Configured services to run as non-root users for improved security
  * Pinned all container images to specific release dates for deterministic deployments
  * Upgraded MongoDB to version 8.2.5 with UBI9-based image for better compatibility
  * Changed MongoDB deployment strategy to Recreate for improved rollout reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->