### PR TITLE
Collect HostedCluster and NodePool YAMLs from GCS artifacts

### DIFF
--- a/scraper/main.go
+++ b/scraper/main.go
@@ -26,7 +26,7 @@ func NewScraper(startURL, suffix, testName string) *Scraper {
 }
 
 func (s *Scraper) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
 	// Connect to MongoDB.

--- a/scraper/processor/artifacts.go
+++ b/scraper/processor/artifacts.go
@@ -1,0 +1,141 @@
+package processor
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/hypershift-community/ci-testgrid/scraper/types"
+)
+
+// fetchArtifacts populates HostedCluster and NodePools fields on each test
+// by fetching YAML artifacts from GCS. Errors are logged and skipped.
+func fetchArtifacts(logURL string, tests []types.Test) {
+	artifactBaseURL := strings.TrimSuffix(logURL, "build-log.txt") + "artifacts/"
+
+	for i := range tests {
+		hc, nps, err := fetchTestArtifacts(artifactBaseURL, tests[i].Name)
+		if err != nil {
+			log.Printf("Error fetching artifacts for test %s: %v", tests[i].Name, err)
+			continue
+		}
+		tests[i].HostedCluster = hc
+		tests[i].NodePools = nps
+	}
+}
+
+// fetchTestArtifacts fetches the HostedCluster and NodePool YAMLs for a single test.
+func fetchTestArtifacts(artifactBaseURL, testName string) (string, []string, error) {
+	namespacesURL := artifactBaseURL + testName + "/namespaces/"
+	namespaces, err := listGCSDirectory(namespacesURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("listing namespaces: %w", err)
+	}
+
+	var hostedCluster string
+	var nodePools []string
+
+	for _, ns := range namespaces {
+		// Each namespace entry should end with "/"
+		if !strings.HasSuffix(ns, "/") {
+			continue
+		}
+
+		hcDir := namespacesURL + ns + "hypershift.openshift.io/hostedclusters/"
+		hcFiles, err := listGCSDirectory(hcDir)
+		if err == nil {
+			for _, f := range hcFiles {
+				if !strings.HasSuffix(f, ".yaml") {
+					continue
+				}
+				if hostedCluster == "" {
+					content, err := fetchFileContent(hcDir + f)
+					if err != nil {
+						log.Printf("Error fetching hostedcluster file %s: %v", f, err)
+						continue
+					}
+					hostedCluster = content
+				}
+			}
+		}
+
+		npDir := namespacesURL + ns + "hypershift.openshift.io/nodepools/"
+		npFiles, err := listGCSDirectory(npDir)
+		if err == nil {
+			for _, f := range npFiles {
+				if !strings.HasSuffix(f, ".yaml") {
+					continue
+				}
+				content, err := fetchFileContent(npDir + f)
+				if err != nil {
+					log.Printf("Error fetching nodepool file %s: %v", f, err)
+					continue
+				}
+				nodePools = append(nodePools, content)
+			}
+		}
+	}
+
+	return hostedCluster, nodePools, nil
+}
+
+// listGCSDirectory fetches a gcsweb HTML directory listing and returns entry names.
+func listGCSDirectory(url string) ([]string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching directory listing: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("directory listing returned status %d", resp.StatusCode)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing directory listing HTML: %w", err)
+	}
+
+	var entries []string
+	doc.Find("a").Each(func(i int, s *goquery.Selection) {
+		href, exists := s.Attr("href")
+		if !exists {
+			return
+		}
+		// Only consider links pointing to GCS paths (filters out UI elements like gsutil/gcloud links)
+		if !strings.HasPrefix(href, "/gcs/") {
+			return
+		}
+		text := strings.TrimSpace(s.Text())
+		// Skip parent directory link
+		if text == "" || text == ".." || text == "../" {
+			return
+		}
+		entries = append(entries, text)
+	})
+
+	return entries, nil
+}
+
+// fetchFileContent fetches a raw file from gcsweb and returns its content as a string.
+func fetchFileContent(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("fetching file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("file fetch returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading file body: %w", err)
+	}
+
+	return string(body), nil
+}

--- a/scraper/processor/artifacts_test.go
+++ b/scraper/processor/artifacts_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package processor
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// These tests require the TEST_LOG_URL environment variable to be set to a
+// gcsweb build-log.txt URL, e.g.:
+//
+//	TEST_LOG_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/.../build-log.txt" \
+//	  go test -tags=integration ./processor/ -v
+
+func testArtifactBaseURL(t *testing.T) string {
+	t.Helper()
+	logURL := os.Getenv("TEST_LOG_URL")
+	if logURL == "" {
+		t.Fatal("TEST_LOG_URL environment variable is required")
+	}
+	if !strings.HasSuffix(logURL, "build-log.txt") {
+		t.Fatalf("TEST_LOG_URL must end with build-log.txt, got: %s", logURL)
+	}
+	return strings.TrimSuffix(logURL, "build-log.txt") + "artifacts/"
+}
+
+func TestFetchTestArtifacts(t *testing.T) {
+	artifactBaseURL := testArtifactBaseURL(t)
+	testName := "TestCreateCluster"
+
+	hostedCluster, nodePools, err := fetchTestArtifacts(artifactBaseURL, testName)
+	if err != nil {
+		t.Fatalf("fetchTestArtifacts returned error: %v", err)
+	}
+
+	if hostedCluster == "" {
+		t.Fatal("expected non-empty hostedCluster YAML")
+	}
+	if !strings.Contains(hostedCluster, "kind: HostedCluster") {
+		t.Errorf("hostedCluster YAML missing 'kind: HostedCluster', got:\n%s", hostedCluster)
+	}
+
+	if len(nodePools) == 0 {
+		t.Fatal("expected at least one nodePool YAML")
+	}
+	for i, np := range nodePools {
+		if !strings.Contains(np, "kind: NodePool") {
+			t.Errorf("nodePool[%d] YAML missing 'kind: NodePool', got:\n%s", i, np)
+		}
+	}
+
+	t.Logf("HostedCluster YAML length: %d bytes", len(hostedCluster))
+	t.Logf("Found %d NodePool(s)", len(nodePools))
+}
+
+func TestListGCSDirectory(t *testing.T) {
+	artifactBaseURL := testArtifactBaseURL(t)
+	url := artifactBaseURL + "TestCreateCluster/namespaces/"
+
+	entries, err := listGCSDirectory(url)
+	if err != nil {
+		t.Fatalf("listGCSDirectory returned error: %v", err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("expected at least one namespace directory entry")
+	}
+
+	t.Logf("Found %d entries: %v", len(entries), entries)
+}

--- a/scraper/processor/process.go
+++ b/scraper/processor/process.go
@@ -20,7 +20,16 @@ func ProcessJob(job *types.Job) ([]types.Test, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return parseLog(resp.Body)
+
+	tests, err := parseLog(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch artifacts for each test
+	fetchArtifacts(job.LogURL, tests)
+
+	return tests, nil
 }
 
 // TestEntry holds a test’s name, its result (pass, fail or skip),

--- a/scraper/types/job.go
+++ b/scraper/types/job.go
@@ -20,6 +20,6 @@ type Test struct {
 	Result        string        `json:"result" bson:"result"`
 	Duration      time.Duration `json:"duration" bson:"duration"`
 	Logs          []string      `json:"logs" bson:"logs"`
-	HostedCluster any           `json:"hosted_cluster" bson:"hosted_cluster"`
-	NodePools     any           `json:"nodepools" bson:"nodepools"`
+	HostedCluster string   `json:"hosted_cluster" bson:"hosted_cluster"`
+	NodePools     []string `json:"nodepools" bson:"nodepools"`
 }


### PR DESCRIPTION
Extend the scraper to fetch post-run HostedCluster and NodePool resource YAMLs from gcsweb artifact directories for each test. The YAMLs are stored as raw strings in the Test struct so a separate mining app can parse timing data from status conditions.

- Change Test.HostedCluster to string and Test.NodePools to []string
- Add processor/artifacts.go with GCS directory listing and file fetching
- Call fetchArtifacts from ProcessJob after log parsing
- Increase context timeout from 60s to 300s for safety margin
- Add integration tests (go:build integration) driven by TEST_LOG_URL env var

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic retrieval and parsing of test artifacts from cloud storage, including HostedCluster and NodePools configuration data.

* **Improvements**
  * Extended scraper timeout to support longer-running operations.
  * Enhanced test processing with integrated artifact fetching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->